### PR TITLE
Fix logic bug in Dutch cost function

### DIFF
--- a/lib/tournament_system/swiss/dutch.rb
+++ b/lib/tournament_system/swiss/dutch.rb
@@ -91,7 +91,7 @@ module TournamentSystem
         cost = 0
 
         # Reduce score distance between teams
-        cost += (state.scores[home_team] || 0 - state.scores[away_team] || 0).abs
+        cost += ((state.scores[home_team] || 0) - (state.scores[away_team] || 0)).abs
 
         # The cost of a duplicate is the score range + 1
         cost += (state.score_range + 1) * state.matches[match_set] unless state.allow_duplicates


### PR DESCRIPTION
Without this fix, the code seems to be interpreted as

`state.scores[home_team]` OR `0 - state.scores[away_team]` or `0`

instead of the intended

`state.scores[home_team] || 0` OR `state.scores[away_team] || 0`